### PR TITLE
Add UI theme preference toggling

### DIFF
--- a/thonny/plugins/theme_and_font_config_page.py
+++ b/thonny/plugins/theme_and_font_config_page.py
@@ -212,6 +212,7 @@ class ThemeAndFontConfigurationPage(ConfigurationPage):
         get_workbench().set_option("view.io_font_size", int(self._io_size_variable.get()))
         get_workbench().set_option("view.io_font_family", self._io_family_variable.get())
         get_workbench().reload_themes()
+        get_workbench().remember_current_ui_theme_preference()
         get_workbench().update_fonts()
 
     def _insert_shell_text(self):


### PR DESCRIPTION
## Summary
- store preferred light and dark UI themes and expose a toggle command with toolbar support
- switch themes based on saved preferences and refresh the dark mode toggle presentation
- refresh saved theme preferences when a user changes themes from the configuration page

## Testing
- python -m compileall thonny

------
https://chatgpt.com/codex/tasks/task_b_68ce807eb5f0832d87afa2895ba8b994