### PR TITLE
Add modern UI themes and update defaults

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,13 @@
 Version history
 ===============
 
+Unreleased
+==========
+
+* Introduce Modern Light UI theme and make it the default alongside a complementary Modern Dark variant.
+
+===============
+
 4.1.7 (2024-12-16)
 ==================
 * Fix PyPI package search, #3401

--- a/thonny/plugins/base_ui_themes.py
+++ b/thonny/plugins/base_ui_themes.py
@@ -616,6 +616,488 @@ def enhanced_aqua() -> CompoundUiThemeSettings:
     ]
 
 
+def modern_light() -> CompoundUiThemeSettings:
+    accent = "#2563EB"
+    accent_hover = "#1D4ED8"
+    accent_pressed = "#1E40AF"
+    surface = "#F5F6FA"
+    surface_alt = "#E5E7EB"
+    canvas = "#FFFFFF"
+    border = "#D0D5DD"
+    focus_border = "#A4C0F5"
+    text_primary = "#111827"
+    text_secondary = "#475467"
+    muted = "#9AA4B2"
+    tooltip_background = "#1F2937"
+    tooltip_foreground = "#F8FAFC"
+
+    return [
+        {
+            ".": {
+                "configure": {
+                    "background": surface,
+                    "foreground": text_primary,
+                    "bordercolor": border,
+                    "darkcolor": surface,
+                    "lightcolor": surface,
+                    "troughcolor": surface_alt,
+                    "selectbackground": accent,
+                    "selectforeground": "#FFFFFF",
+                    "font": "TkDefaultFont",
+                },
+                "map": {
+                    "background": [("disabled", surface), ("active", surface_alt)],
+                    "foreground": [("disabled", muted)],
+                    "selectbackground": [("!focus", accent_hover)],
+                    "selectforeground": [("!focus", "#FFFFFF")],
+                },
+            },
+            "TFrame": {"configure": {"background": surface}},
+            "TLabel": {"configure": {"background": surface, "foreground": text_primary}},
+            "Secondary.TLabel": {"configure": {"foreground": text_secondary}},
+            "Url.TLabel": {"configure": {"foreground": accent}},
+            "Tip.TLabel": {
+                "configure": {"foreground": tooltip_foreground, "background": tooltip_background}
+            },
+            "Tip.TFrame": {"configure": {"background": tooltip_background}},
+            "TSeparator": {
+                "configure": {"background": border, "borderwidth": 0, "relief": "flat"}
+            },
+            "TButton": {
+                "configure": {
+                    "background": accent,
+                    "foreground": "#FFFFFF",
+                    "bordercolor": accent,
+                    "lightcolor": accent,
+                    "darkcolor": accent,
+                    "padding": [scale(8), scale(4)],
+                    "relief": "flat",
+                },
+                "map": {
+                    "background": [
+                        ("disabled", surface_alt),
+                        ("pressed", accent_pressed),
+                        ("active", accent_hover),
+                    ],
+                    "bordercolor": [("focus", focus_border)],
+                    "foreground": [("disabled", "#FFFFFF")],
+                },
+            },
+            "Toolbutton": {
+                "configure": {
+                    "background": surface,
+                    "foreground": text_secondary,
+                    "padding": [scale(6), scale(4)],
+                    "relief": "flat",
+                },
+                "map": {
+                    "background": [
+                        ("disabled", surface),
+                        ("pressed", accent_pressed),
+                        ("active", surface_alt),
+                        ("selected", accent),
+                    ],
+                    "foreground": [
+                        ("disabled", muted),
+                        ("pressed", "#FFFFFF"),
+                        ("selected", "#FFFFFF"),
+                    ],
+                },
+            },
+            "TMenubutton": {
+                "configure": {
+                    "background": canvas,
+                    "foreground": text_secondary,
+                    "bordercolor": border,
+                    "lightcolor": border,
+                    "darkcolor": border,
+                    "padding": [scale(8), scale(4)],
+                    "relief": "flat",
+                },
+                "map": {
+                    "background": [
+                        ("disabled", canvas),
+                        ("pressed", accent_pressed),
+                        ("active", surface_alt),
+                    ],
+                    "foreground": [
+                        ("disabled", muted),
+                        ("pressed", "#FFFFFF"),
+                        ("active", text_primary),
+                    ],
+                    "bordercolor": [("focus", accent)],
+                },
+            },
+            "TCheckbutton": {
+                "configure": {
+                    "foreground": text_secondary,
+                    "indicatorbackground": canvas,
+                    "indicatorforeground": accent,
+                    "padding": [scale(4), scale(2)],
+                },
+                "map": {
+                    "foreground": [("disabled", muted), ("selected", text_primary)],
+                    "indicatorbackground": [
+                        ("disabled", surface_alt),
+                        ("selected", accent),
+                    ],
+                    "indicatorforeground": [
+                        ("disabled", muted),
+                        ("selected", "#FFFFFF"),
+                    ],
+                },
+            },
+            "TRadiobutton": {
+                "configure": {
+                    "foreground": text_secondary,
+                    "indicatorbackground": canvas,
+                    "indicatorforeground": accent,
+                    "padding": [scale(4), scale(2)],
+                },
+                "map": {
+                    "foreground": [("disabled", muted), ("selected", text_primary)],
+                    "indicatorbackground": [
+                        ("disabled", surface_alt),
+                        ("selected", accent),
+                    ],
+                    "indicatorforeground": [
+                        ("disabled", muted),
+                        ("selected", "#FFFFFF"),
+                    ],
+                },
+            },
+            "TEntry": {
+                "configure": {
+                    "fieldbackground": canvas,
+                    "foreground": text_primary,
+                    "insertcolor": accent,
+                    "lightcolor": border,
+                    "darkcolor": border,
+                    "bordercolor": border,
+                    "padding": [scale(4), scale(4)],
+                },
+                "map": {
+                    "fieldbackground": [("readonly", canvas)],
+                    "bordercolor": [("focus", accent)],
+                    "lightcolor": [("focus", accent)],
+                    "darkcolor": [("focus", accent)],
+                    "foreground": [("disabled", muted)],
+                },
+            },
+            "TCombobox": {
+                "configure": {
+                    "background": canvas,
+                    "fieldbackground": canvas,
+                    "foreground": text_primary,
+                    "selectbackground": canvas,
+                    "selectforeground": text_primary,
+                    "bordercolor": border,
+                    "lightcolor": border,
+                    "darkcolor": border,
+                    "arrowcolor": text_secondary,
+                    "padding": [scale(4), scale(2), scale(4), scale(2)],
+                },
+                "map": {
+                    "background": [("active", canvas)],
+                    "fieldbackground": [("readonly", canvas)],
+                    "selectbackground": [("readonly", canvas)],
+                    "selectforeground": [("readonly", text_primary)],
+                    "foreground": [("disabled", muted)],
+                    "arrowcolor": [("disabled", muted)],
+                    "bordercolor": [("focus", accent)],
+                },
+            },
+            "ComboboxPopdownFrame": {
+                "configure": {
+                    "borderwidth": scale(1),
+                    "relief": "solid",
+                    "background": canvas,
+                    "bordercolor": border,
+                }
+            },
+            "TSpinbox": {
+                "configure": {
+                    "background": canvas,
+                    "fieldbackground": canvas,
+                    "foreground": text_primary,
+                    "arrowsize": scale(12),
+                    "bordercolor": border,
+                },
+                "map": {
+                    "fieldbackground": [("readonly", canvas)],
+                    "foreground": [("disabled", muted)],
+                    "arrowcolor": [("disabled", muted)],
+                    "bordercolor": [("focus", accent)],
+                },
+            },
+            "TNotebook": {
+                "configure": {
+                    "background": surface,
+                    "bordercolor": border,
+                    "tabmargins": [scale(4), scale(2), scale(4), 0],
+                }
+            },
+            "AutomaticNotebook.TNotebook": {
+                "configure": {"background": surface, "bordercolor": border}
+            },
+            "ButtonNotebook.TNotebook": {
+                "configure": {"background": surface, "bordercolor": border}
+            },
+            "TNotebook.Tab": {
+                "configure": {
+                    "padding": [scale(10), scale(6)],
+                    "background": surface,
+                    "foreground": text_secondary,
+                    "borderwidth": scale(1),
+                    "bordercolor": surface,
+                    "lightcolor": surface,
+                    "darkcolor": surface,
+                },
+                "map": {
+                    "background": [
+                        ("selected", canvas),
+                        ("!selected", surface),
+                        ("disabled", surface),
+                    ],
+                    "foreground": [
+                        ("selected", text_primary),
+                        ("disabled", muted),
+                    ],
+                    "bordercolor": [
+                        ("selected", accent),
+                        ("focus", accent),
+                        ("!selected", surface),
+                    ],
+                    "lightcolor": [
+                        ("selected", accent),
+                        ("!selected", surface),
+                    ],
+                    "darkcolor": [
+                        ("selected", accent),
+                        ("!selected", surface),
+                    ],
+                },
+            },
+            "ButtonNotebook.TNotebook.Tab": {
+                "configure": {"padding": [scale(10), scale(4)]}
+            },
+            "Treeview": {
+                "configure": {
+                    "background": canvas,
+                    "foreground": text_primary,
+                    "fieldbackground": canvas,
+                    "borderwidth": 0,
+                    "relief": "flat",
+                },
+                "map": {
+                    "background": [
+                        ("selected", "focus", accent),
+                        ("selected", "!focus", accent_hover),
+                    ],
+                    "foreground": [
+                        ("selected", "#FFFFFF"),
+                        ("disabled", muted),
+                    ],
+                },
+            },
+            "Treeview.Heading": {
+                "configure": {
+                    "background": surface,
+                    "foreground": text_secondary,
+                    "borderwidth": scale(1),
+                    "bordercolor": border,
+                    "lightcolor": surface,
+                    "darkcolor": surface,
+                    "padding": [scale(6), scale(3)],
+                    "relief": "flat",
+                },
+                "map": {
+                    "background": [
+                        ("active", surface_alt),
+                        ("pressed", accent_pressed),
+                    ],
+                    "foreground": [
+                        ("active", text_primary),
+                        ("pressed", "#FFFFFF"),
+                    ],
+                },
+            },
+            "TScrollbar": {
+                "configure": {
+                    "gripcount": 0,
+                    "borderwidth": 0,
+                    "relief": "flat",
+                    "background": border,
+                    "darkcolor": border,
+                    "lightcolor": border,
+                    "troughcolor": surface_alt,
+                },
+                "map": {
+                    "background": [
+                        ("disabled", border),
+                        ("active", accent),
+                        ("pressed", accent_pressed),
+                    ],
+                    "troughcolor": [("disabled", surface)],
+                },
+            },
+            "Vertical.TScrollbar": {
+                "layout": [
+                    (
+                        "Vertical.Scrollbar.trough",
+                        {
+                            "sticky": "ns",
+                            "children": [
+                                ("Vertical.Scrollbar.thumb", {"expand": "1", "sticky": "nswe"})
+                            ],
+                        },
+                    )
+                ]
+            },
+            "Horizontal.TScrollbar": {
+                "layout": [
+                    (
+                        "Horizontal.Scrollbar.trough",
+                        {
+                            "sticky": "we",
+                            "children": [
+                                ("Horizontal.Scrollbar.thumb", {"expand": "1", "sticky": "nswe"})
+                            ],
+                        },
+                    )
+                ],
+                "map": {
+                    "background": [
+                        ("disabled", border),
+                        ("active", accent),
+                        ("pressed", accent_pressed),
+                    ],
+                    "troughcolor": [("disabled", surface)],
+                },
+            },
+            "Menubar": {
+                "configure": {
+                    "custom": 1 if running_on_windows() else 0,
+                    "background": surface,
+                    "foreground": text_secondary,
+                    "activebackground": accent,
+                    "activeforeground": "#FFFFFF",
+                    "relief": "flat",
+                }
+            },
+            "Menu": {
+                "configure": {
+                    "background": canvas,
+                    "foreground": text_primary,
+                    "selectcolor": accent,
+                    "activebackground": accent,
+                    "activeforeground": "#FFFFFF",
+                    "borderwidth": 0,
+                    "relief": "flat",
+                }
+            },
+            "CustomMenubarLabel.TLabel": {
+                "configure": {
+                    "background": surface,
+                    "foreground": text_secondary,
+                    "padding": [scale(10), scale(4), 0, scale(10)],
+                }
+            },
+            "Text": {
+                "configure": {
+                    "background": canvas,
+                    "foreground": text_primary,
+                    "insertbackground": accent,
+                }
+            },
+            "Gutter": {
+                "configure": {"background": surface_alt, "foreground": muted}
+            },
+            "Listbox": {
+                "configure": {
+                    "background": canvas,
+                    "foreground": text_primary,
+                    "selectbackground": accent,
+                    "selectforeground": "#FFFFFF",
+                    "disabledforeground": muted,
+                    "highlightbackground": border,
+                    "highlightcolor": accent,
+                    "highlightthickness": scale(1),
+                }
+            },
+            "ViewBody.TFrame": {"configure": {"background": canvas}},
+            "ViewToolbar.TFrame": {"configure": {"background": surface}},
+            "ViewToolbar.Toolbutton": {
+                "configure": {
+                    "background": surface,
+                    "foreground": text_secondary,
+                    "padding": [scale(6), scale(4)],
+                    "relief": "flat",
+                },
+                "map": {
+                    "background": [
+                        ("disabled", surface),
+                        ("active", surface_alt),
+                        ("pressed", accent_pressed),
+                        ("selected", accent),
+                    ],
+                    "foreground": [
+                        ("disabled", muted),
+                        ("pressed", "#FFFFFF"),
+                        ("selected", "#FFFFFF"),
+                    ],
+                },
+            },
+            "ViewToolbar.TLabel": {
+                "configure": {"background": surface, "foreground": text_secondary}
+            },
+            "ViewTab.TLabel": {
+                "configure": {
+                    "background": surface,
+                    "foreground": text_secondary,
+                    "padding": [scale(8), scale(2)],
+                },
+                "map": {"background": [("hover", surface_alt)]},
+            },
+            "Active.ViewTab.TLabel": {
+                "configure": {"background": canvas, "foreground": text_primary}
+            },
+            "Inactive.ViewTab.TLabel": {
+                "configure": {"foreground": text_secondary}
+            },
+            "TProgressbar": {
+                "configure": {
+                    "background": accent,
+                    "troughcolor": surface_alt,
+                    "bordercolor": surface,
+                }
+            },
+            "TScale": {
+                "configure": {
+                    "background": accent,
+                    "troughcolor": surface_alt,
+                    "borderwidth": 0,
+                    "lightcolor": accent,
+                    "darkcolor": accent,
+                    "gripcount": 0,
+                }
+            },
+            "Sash": {
+                "configure": {
+                    "background": border,
+                    "borderwidth": 0,
+                    "sashthickness": ems_to_pixels(0.5),
+                    "gripcount": 0,
+                }
+            },
+        },
+        _paned_window_settings(),
+        _menu_settings(),
+        _link_settings(),
+        _button_notebook_settings(),
+    ]
+
+
 def load_plugin() -> None:
     from tkinter import ttk
 

--- a/thonny/plugins/clean_ui_themes.py
+++ b/thonny/plugins/clean_ui_themes.py
@@ -4,6 +4,7 @@ from thonny import get_workbench
 from thonny.misc_utils import running_on_windows
 from thonny.ui_utils import scale
 from thonny.workbench import UiThemeSettings
+from .base_ui_themes import modern_light
 
 
 def clean(
@@ -303,6 +304,34 @@ def clean(
 
 def load_plugin() -> None:
     dark_images = {"tab-close-active": "tab-close-active-clam-dark"}
+
+    modern_light_images = {
+        "tab-close": "tab-close",
+        "tab-close-active": "tab-close-active",
+    }
+
+    get_workbench().add_ui_theme(
+        "Modern Light",
+        "clam",
+        modern_light,
+        modern_light_images,
+    )
+
+    get_workbench().add_ui_theme(
+        "Modern Dark",
+        "clam",
+        clean(
+            frame_background="#111827",
+            text_background="#0F172A",
+            normal_detail="#1F2937",
+            high_detail="#1D4ED8",
+            low_detail="#0B1623",
+            normal_foreground="#E2E8F0",
+            high_foreground="#F8FAFC",
+            low_foreground="#64748B",
+        ),
+        dark_images,
+    )
 
     get_workbench().add_ui_theme(
         "Clean Dark",

--- a/thonny/workbench.py
+++ b/thonny/workbench.py
@@ -142,7 +142,7 @@ class Workbench(tk.Tk):
         self._image_mapping_by_theme = (
             {}
         )  # type: Dict[str, Dict[str, str]] # theme-based alternative images
-        self._current_theme_name = "clam"  # will be overwritten later
+        self._current_theme_name = "Modern Light"  # will be overwritten later
         self._backends = {}  # type: Dict[str, BackendSpec]
         self._commands = []  # type: List[Dict[str, Any]]
         self._registered_commands = []  # type: List[Dict[str, Any]]
@@ -1441,6 +1441,8 @@ class Workbench(tk.Tk):
 
     def get_default_ui_theme(self) -> str:
         available_themes = self.get_usable_ui_theme_names()
+        if "Modern Light" in available_themes:
+            return "Modern Light"
         if "Windows" in available_themes:
             return "Windows"
         elif running_on_rpi() and "Raspberry Pi" in available_themes:
@@ -1452,6 +1454,8 @@ class Workbench(tk.Tk):
 
     def get_default_dark_ui_theme(self) -> str:
         available_themes = list(self.get_usable_ui_theme_names())
+        if "Modern Dark" in available_themes:
+            return "Modern Dark"
         if "Clean Dark" in available_themes:
             return "Clean Dark"
 


### PR DESCRIPTION
## Summary
- add a Modern Light UI theme builder with flatter surfaces, accent colours and lighter borders
- register new Modern Light and Modern Dark themes and make them the preferred defaults for fresh installs
- document the theme change in the changelog

## Testing
- python -m compileall thonny/plugins/base_ui_themes.py thonny/plugins/clean_ui_themes.py thonny/workbench.py

------
https://chatgpt.com/codex/tasks/task_b_68ce90a63738832d9b2672fb1f1ee0cb