### PR TITLE
Remove Support Ukraine toolbar button

### DIFF
--- a/thonny/workbench.py
+++ b/thonny/workbench.py
@@ -13,7 +13,6 @@ import sys
 import tkinter as tk
 import tkinter.font as tk_font
 import traceback
-import webbrowser
 from logging import getLogger
 from threading import Thread
 from tkinter import messagebox, ttk
@@ -49,7 +48,6 @@ from thonny.ui_utils import (
     AutomaticNotebook,
     AutomaticPanedWindow,
     caps_lock_is_on,
-    create_action_label,
     create_tooltip,
     ems_to_pixels,
     get_hyperlink_cursor,
@@ -717,17 +715,6 @@ class Workbench(tk.Tk):
                 group=101,
             )
 
-        self.add_command(
-            "SupportUkraine",
-            "help",
-            tr("Support Ukraine"),
-            self._support_ukraine,
-            image="Ukraine",
-            caption=tr("Support"),
-            include_in_toolbar=True,
-            group=101,
-        )
-
         if thonny.in_debug_mode():
             self.bind_all("<Control-Shift-Alt-D>", self._print_state_for_debugging, True)
 
@@ -813,21 +800,7 @@ class Workbench(tk.Tk):
         self._status_label = ttk.Label(self._statusbar, text="")
         self._status_label.grid(row=1, column=1, sticky="w")
 
-        # self._init_support_ukraine_bar()
         self._init_backend_switcher()
-
-    def _init_support_ukraine_bar(self) -> None:
-        ukraine_label = create_action_label(
-            self._statusbar,
-            tr("Support Ukraine"),
-            self._support_ukraine,
-            # image=self.get_image("Ukraine"),
-            # compound="left"
-        )
-        ukraine_label.grid(row=1, column=1, sticky="wsn")
-
-    def _support_ukraine(self, event=None) -> None:
-        webbrowser.open("https://github.com/thonny/thonny/wiki/Support-Ukraine")
 
     def _init_backend_switcher(self):
         # Set up the menu


### PR DESCRIPTION
## Summary
- remove the Support Ukraine toolbar command and associated helper from the workbench to eliminate the button

## Testing
- python -m compileall thonny/workbench.py

------
https://chatgpt.com/codex/tasks/task_b_68ce984183e4832d9ae09a0749474b11